### PR TITLE
Merge BuddyBoss and profile warning tags for shortcode

### DIFF
--- a/content-warning.php
+++ b/content-warning.php
@@ -198,7 +198,17 @@ function deaddove_content_warning_shortcode($atts, $content = null) {
     $tags = array_map('trim', explode(',', $atts['tags']));
      
     $admin_warning_tags = get_option('deaddove_warning_tags', []);
-    $user_tags = get_user_meta(get_current_user_id(), 'deaddove_user_warning_tags', true) ?: $admin_warning_tags;
+
+    // Retrieve user settings from both BuddyBoss and WordPress profile screens.
+    $bb_tags = get_user_meta(get_current_user_id(), 'deaddove_user_warning_tags', true);
+    $wp_tags = get_user_meta(get_current_user_id(), 'deaddove_user_warning_terms', true);
+
+    // Ensure both values are arrays before merging.
+    $bb_tags = is_array($bb_tags) ? $bb_tags : [];
+    $wp_tags = is_array($wp_tags) ? $wp_tags : [];
+
+    $merged_tags = array_unique(array_merge($bb_tags, $wp_tags));
+    $user_tags = !empty($merged_tags) ? $merged_tags : $admin_warning_tags;
 
     $warning_texts = [];
     foreach ($tags as $tag_slug) {

--- a/readme.txt
+++ b/readme.txt
@@ -40,9 +40,10 @@ Content that has been tagged with a term that triggers a content warning for the
 3. Add a description to each term to provide the warning text.
 
 ### **User Settings**  
-1. Users who have access to the Wordpress Dashboard can go to **Your Profile** to adjust their warning settings.  
+1. Users who have access to the Wordpress Dashboard can go to **Your Profile** to adjust their warning settings.
 2. BuddyBoss users can adjust their warning settings by going to **Account Settings**, **Content Warning Settings**.
-3. Users can disable warnings for certain terms set by the admin or enable warnings for terms that were not set by the admin.
+3. Selections made in either location are merged, so a user with access to both screens sees warnings based on the combined list of terms.
+4. Users can disable warnings for certain terms set by the admin or enable warnings for terms that were not set by the admin.
 
 ### **Post term usage**
 To apply a content warning to an entire post, apply a term that requires a content warning to the post. The content warning taxonomy will appear in the post editor screen, alongside tags, and are used in the same way.


### PR DESCRIPTION
## Summary
- Merge user warning tags from both BuddyBoss and WordPress profile settings when rendering shortcode content warnings
- Document that selections from both settings screens are combined

## Testing
- `php -l content-warning.php`

------
https://chatgpt.com/codex/tasks/task_e_68ba22a64fd483278747f6791e415992