### PR TITLE
Avoid line breaks for inline content warnings

### DIFF
--- a/content-warning.php
+++ b/content-warning.php
@@ -223,7 +223,10 @@ function deaddove_content_warning_shortcode($atts, $content = null) {
     if (strpos($_SERVER['REQUEST_URI'], '/add-new-post') !== false) {
         return '<p class="deaddove-block-description" tags="'.$atts['tags'].'">' . $content . '</p><br>';
     }
-    return '
+    $has_block_content = preg_match('/<\s*(div|p|h[1-6]|ul|ol|li|table|blockquote|pre|figure|section|article)/i', $content);
+
+    if ($has_block_content) {
+        return '
         <div class="deaddove-modal-wrapper">
             <div class="deaddove-modal" style="display:none;">
                 <div class="deaddove-modal-content">
@@ -239,8 +242,26 @@ function deaddove_content_warning_shortcode($atts, $content = null) {
                 ' . do_shortcode($content) . '
             </div>
         </div>';
+    }
+
+    return '
+        <span class="deaddove-modal-wrapper deaddove-inline-wrapper">
+            <span class="deaddove-modal" style="display:none;">
+                <span class="deaddove-modal-content">
+                    <span>' . $all_warnings . '</span>
+                    <span class="modal-buttons">
+                        <button class="deaddove-show-content-btn">Show this content</button>
+                        <button class="deaddove-hide-content-btn">Keep it hidden</button>
+                    </span>
+                    <small><a href="#deaddove-warning-settings3" class="deaddove-settings-link">Modify your content warning settings</a></small>
+                </span>
+            </span>
+            <span class="deaddove-blurred-content deaddove-blur">
+                ' . do_shortcode($content) . '
+            </span>
+        </span>';
 }
-add_shortcode('content_warning', 'deaddove_content_warning_shortcode');  
+add_shortcode('content_warning', 'deaddove_content_warning_shortcode');
 
 // Admin settings page
 function deaddove_settings_page() {

--- a/css/deaddove-style.css
+++ b/css/deaddove-style.css
@@ -4,6 +4,12 @@
     position: relative;
 }
 
+.deaddove-inline-wrapper {
+    padding: 0;
+    margin: 0;
+    display: inline;
+}
+
 .deaddove-modal {
     display: none; /* Hide by default, shown by JavaScript */
     position: fixed;


### PR DESCRIPTION
## Summary
- Detect block-level content in `[content_warning]` shortcode output.
- Wrap inline shortcode content in span-based modal markup to avoid line breaks.
- Add CSS rules for inline wrappers.

## Testing
- `php -l content-warning.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba2c83a7348327a7c17960a3e95ec2